### PR TITLE
branch automerge lockFileMaintenance

### DIFF
--- a/base.json
+++ b/base.json
@@ -8,10 +8,14 @@
     ":semanticCommits",
     ":semanticCommitScope(deps)",
     "docker:enableMajor",
-    ":maintainLockFilesWeekly",
     ":masterIssue",
     "group:linters"
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "automergeType": "branch"
+  },
   "assignees": ["rarkins", "viceice"],
   "prCreation": "not-pending",
   "docker": {


### PR DESCRIPTION
For repos with branch protection, this should still mean PR automerges work.