### PR TITLE
chore: improve commitMessage for renovate/renovate docker tags docs update

### DIFF
--- a/base.json
+++ b/base.json
@@ -66,10 +66,9 @@
       "description": "Update references to Docker tags for renovate/renovate in Markdown files",
       "packageNames": ["renovate/renovate"],
       "paths": [".md"],
-      "extends": ["schedule:weekly"],
+      "extends": ["schedule:weekly", ":semanticCommitScope(docs)"],
       "automerge": true,
       "stabilityDays": 0,
-      "commitMessagePrefix": "docs:",
       "commitMessageTopic": "references to {{{depName}}}",
       "additionalBranchPrefix": "docs-"
     }

--- a/base.json
+++ b/base.json
@@ -68,7 +68,10 @@
       "paths": [".md"],
       "extends": ["schedule:weekly"],
       "automerge": true,
-      "stabilityDays": 0
+      "stabilityDays": 0,
+      "commitMessagePrefix": "docs:",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "references to {{{depName}}}"
     }
   ],
   "regexManagers": [

--- a/base.json
+++ b/base.json
@@ -71,7 +71,7 @@
       "stabilityDays": 0,
       "commitMessageTopic": "references to {{{depName}}}",
       "semanticCommitType": "docs",
-      "semanticCommitScope": null
+      "semanticCommitScope": null,
       "additionalBranchPrefix": "docs-"
     }
   ],

--- a/base.json
+++ b/base.json
@@ -63,6 +63,7 @@
       "groupName": "prettier packages"
     },
     {
+      "description": "Update references to Docker tags for renovate/renovate in Markdown files",
       "packageNames": ["renovate/renovate"],
       "paths": [".md"],
       "extends": ["schedule:weekly"],

--- a/base.json
+++ b/base.json
@@ -70,8 +70,8 @@
       "automerge": true,
       "stabilityDays": 0,
       "commitMessagePrefix": "docs:",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "references to {{{depName}}}"
+      "commitMessageTopic": "references to {{{depName}}}",
+      "additionalBranchPrefix": "docs-"
     }
   ],
   "regexManagers": [

--- a/base.json
+++ b/base.json
@@ -66,10 +66,12 @@
       "description": "Update references to Docker tags for renovate/renovate in Markdown files",
       "packageNames": ["renovate/renovate"],
       "paths": [".md"],
-      "extends": ["schedule:weekly", ":semanticCommitScope(docs)"],
+      "extends": ["schedule:weekly"],
       "automerge": true,
       "stabilityDays": 0,
       "commitMessageTopic": "references to {{{depName}}}",
+      "semanticCommitType": "docs",
+      "semanticCommitScope": null
       "additionalBranchPrefix": "docs-"
     }
   ],


### PR DESCRIPTION
## Changes:

- Adds `description` field that explains what this is doing in plain English
- Change `commitMessage` to be: `docs: update references to renovate/renovate`
- Use `additionalBranchPrefix` to separate this PR from normal PRs

## Context:

Improves the PR title and commit messages used for PRs like: https://github.com/renovatebot/renovate/pull/8114

This is my first attempt, so please review it thoroughly.
Is there a way I can try this out away from production?
Especially as any mistakes will get auto-merged on the weekly runs...